### PR TITLE
Add better rst generation for class names in docstrings

### DIFF
--- a/sphinxcontrib/writers/rst.py
+++ b/sphinxcontrib/writers/rst.py
@@ -80,15 +80,18 @@ class RstTranslator(TextTranslator):
 
     def add_text(self, text):
         self.states[-1].append((-1, text))
+
     def new_state(self, indent=STDINDENT):
         self.states.append([])
         self.stateindent.append(indent)
+
     def end_state(self, wrap=True, end=[''], first=None):
         content = self.states.pop()
         maxindent = sum(self.stateindent)
         indent = self.stateindent.pop()
         result = []
         toformat = []
+
         def do_format():
             if not toformat:
                 return
@@ -116,6 +119,7 @@ class RstTranslator(TextTranslator):
 
     def visit_document(self, node):
         self.new_state(0)
+
     def depart_document(self, node):
         self.end_state()
         self.body = self.nl.join(line and (' '*indent + line)
@@ -129,11 +133,13 @@ class RstTranslator(TextTranslator):
     def visit_section(self, node):
         self._title_char = self.sectionchars[self.sectionlevel]
         self.sectionlevel += 1
+
     def depart_section(self, node):
         self.sectionlevel -= 1
 
     def visit_topic(self, node):
         self.new_state(0)
+
     def depart_topic(self, node):
         self.end_state()
 
@@ -143,6 +149,7 @@ class RstTranslator(TextTranslator):
     def visit_rubric(self, node):
         self.new_state(0)
         self.add_text('-[ ')
+
     def depart_rubric(self, node):
         self.add_text(' ]-')
         self.end_state()
@@ -150,12 +157,14 @@ class RstTranslator(TextTranslator):
     def visit_compound(self, node):
         # self.log_unknown("compount", node)
         pass
+
     def depart_compound(self, node):
         pass
 
     def visit_glossary(self, node):
         # self.log_unknown("glossary", node)
         pass
+
     def depart_glossary(self, node):
         pass
 
@@ -164,6 +173,7 @@ class RstTranslator(TextTranslator):
             self.add_text(node.astext()+': ')
             raise nodes.SkipNode
         self.new_state(0)
+
     def depart_title(self, node):
         if isinstance(node.parent, nodes.section):
             char = self._title_char
@@ -176,16 +186,19 @@ class RstTranslator(TextTranslator):
     def visit_subtitle(self, node):
         # self.log_unknown("subtitle", node)
         pass
+
     def depart_subtitle(self, node):
         pass
 
     def visit_attribution(self, node):
         self.add_text('-- ')
+
     def depart_attribution(self, node):
         pass
 
     def visit_desc(self, node):
         self.new_state(0)
+
     def depart_desc(self, node):
         self.end_state()
 
@@ -194,6 +207,7 @@ class RstTranslator(TextTranslator):
             self.add_text('**')
         else:
             self.add_text('``')
+
     def depart_desc_signature(self, node):
         if node.parent['objtype'] in ('class', 'exception', 'method', 'function'):
             self.add_text('**')
@@ -203,29 +217,34 @@ class RstTranslator(TextTranslator):
     def visit_desc_name(self, node):
         # self.log_unknown("desc_name", node)
         pass
+
     def depart_desc_name(self, node):
         pass
 
     def visit_desc_addname(self, node):
         # self.log_unknown("desc_addname", node)
         pass
+
     def depart_desc_addname(self, node):
         pass
 
     def visit_desc_type(self, node):
         # self.log_unknown("desc_type", node)
         pass
+
     def depart_desc_type(self, node):
         pass
 
     def visit_desc_returns(self, node):
         self.add_text(' -> ')
+
     def depart_desc_returns(self, node):
         pass
 
     def visit_desc_parameterlist(self, node):
         self.add_text('(')
         self.first_param = 1
+
     def depart_desc_parameterlist(self, node):
         self.add_text(')')
 
@@ -239,37 +258,44 @@ class RstTranslator(TextTranslator):
 
     def visit_desc_optional(self, node):
         self.add_text('[')
+
     def depart_desc_optional(self, node):
         self.add_text(']')
 
     def visit_desc_annotation(self, node):
         content = node.astext()
+
         if len(content) > MAXWIDTH:
             h = int(MAXWIDTH/3)
             content = content[:h] + " ... " + content[-h:]
             self.add_text(content)
             raise nodes.SkipNode
+
     def depart_desc_annotation(self, node):
         pass
 
     def visit_refcount(self, node):
         pass
+
     def depart_refcount(self, node):
         pass
 
     def visit_desc_content(self, node):
         self.new_state(self.indent)
+
     def depart_desc_content(self, node):
         self.end_state()
 
     def visit_figure(self, node):
         self.new_state(self.indent)
+
     def depart_figure(self, node):
         self.end_state()
 
     def visit_caption(self, node):
         # self.log_unknown("caption", node)
         pass
+
     def depart_caption(self, node):
         pass
 
@@ -291,12 +317,14 @@ class RstTranslator(TextTranslator):
 
     def visit_seealso(self, node):
         self.new_state(self.indent)
+
     def depart_seealso(self, node):
         self.end_state(first='')
 
     def visit_footnote(self, node):
         self._footnote = node.children[0].astext().strip()
         self.new_state(len(self._footnote) + self.indent)
+
     def depart_footnote(self, node):
         self.end_state(first='[%s] ' % self._footnote)
 
@@ -306,6 +334,7 @@ class RstTranslator(TextTranslator):
         else:
             self._citlabel = ''
         self.new_state(len(self._citlabel) + self.indent)
+
     def depart_citation(self, node):
         self.end_state(first='[%s] ' % self._citlabel)
 
@@ -317,16 +346,19 @@ class RstTranslator(TextTranslator):
     def visit_option_list(self, node):
         # self.log_unknown("option_list", node)
         pass
+
     def depart_option_list(self, node):
         pass
 
     def visit_option_list_item(self, node):
         self.new_state(0)
+
     def depart_option_list_item(self, node):
         self.end_state()
 
     def visit_option_group(self, node):
         self._firstoption = True
+
     def depart_option_group(self, node):
         self.add_text('     ')
 
@@ -335,23 +367,27 @@ class RstTranslator(TextTranslator):
             self._firstoption = False
         else:
             self.add_text(', ')
+
     def depart_option(self, node):
         pass
 
     def visit_option_string(self, node):
         # self.log_unknown("option_string", node)
         pass
+
     def depart_option_string(self, node):
         pass
 
     def visit_option_argument(self, node):
         self.add_text(node['delimiter'])
+
     def depart_option_argument(self, node):
         pass
 
     def visit_description(self, node):
         # self.log_unknown("description", node)
         pass
+
     def depart_description(self, node):
         pass
 
@@ -365,22 +401,26 @@ class RstTranslator(TextTranslator):
     def visit_tgroup(self, node):
         # self.log_unknown("tgroup", node)
         pass
+
     def depart_tgroup(self, node):
         pass
 
     def visit_thead(self, node):
         # self.log_unknown("thead", node)
         pass
+
     def depart_thead(self, node):
         pass
 
     def visit_tbody(self, node):
         self.table.append('sep')
+
     def depart_tbody(self, node):
         pass
 
     def visit_row(self, node):
         self.table.append([])
+
     def depart_row(self, node):
         pass
 
@@ -389,6 +429,7 @@ class RstTranslator(TextTranslator):
             raise NotImplementedError('Column or row spanning cells are '
                                       'not implemented.')
         self.new_state(0)
+
     def depart_entry(self, node):
         text = self.nl.join(self.nl.join(x[1]) for x in self.states.pop())
         self.stateindent.pop()
@@ -399,6 +440,7 @@ class RstTranslator(TextTranslator):
             raise NotImplementedError('Nested tables are not supported.')
         self.new_state(0)
         self.table = [[]]
+
     def depart_table(self, node):
         lines = self.table[1:]
         fmted_rows = []
@@ -472,16 +514,19 @@ class RstTranslator(TextTranslator):
 
     def visit_bullet_list(self, node):
         self.list_counter.append(-1)
+
     def depart_bullet_list(self, node):
         self.list_counter.pop()
 
     def visit_enumerated_list(self, node):
         self.list_counter.append(0)
+
     def depart_enumerated_list(self, node):
         self.list_counter.pop()
 
     def visit_definition_list(self, node):
         self.list_counter.append(-2)
+
     def depart_definition_list(self, node):
         self.list_counter.pop()
 
@@ -496,6 +541,7 @@ class RstTranslator(TextTranslator):
             # enumerated list
             self.list_counter[-1] += 1
             self.new_state(len(str(self.list_counter[-1])) + self.indent)
+
     def depart_list_item(self, node):
         if self.list_counter[-1] == -1:
             self.end_state(first='* ', end=None)
@@ -507,11 +553,13 @@ class RstTranslator(TextTranslator):
     def visit_definition_list_item(self, node):
         self._li_has_classifier = len(node) >= 2 and \
                                   isinstance(node[1], nodes.classifier)
+
     def depart_definition_list_item(self, node):
         pass
 
     def visit_term(self, node):
         self.new_state(0)
+
     def depart_term(self, node):
         if not self._li_has_classifier:
             self.end_state(end=None)
@@ -522,27 +570,32 @@ class RstTranslator(TextTranslator):
 
     def visit_classifier(self, node):
         self.add_text(' : ')
+
     def depart_classifier(self, node):
         self.end_state(end=None)
 
     def visit_definition(self, node):
         self.new_state(self.indent)
+
     def depart_definition(self, node):
         self.end_state()
 
     def visit_field_list(self, node):
         # self.log_unknown("field_list", node)
         pass
+
     def depart_field_list(self, node):
         pass
 
     def visit_field(self, node):
         self.new_state(0)
+
     def depart_field(self, node):
         self.end_state(end=None)
 
     def visit_field_name(self, node):
         self.add_text(':')
+
     def depart_field_name(self, node):
         self.add_text(':')
         content = node.astext()
@@ -550,33 +603,39 @@ class RstTranslator(TextTranslator):
 
     def visit_field_body(self, node):
         self.new_state(self.indent)
+
     def depart_field_body(self, node):
         self.end_state()
 
     def visit_centered(self, node):
         pass
+
     def depart_centered(self, node):
         pass
 
     def visit_hlist(self, node):
         # self.log_unknown("hlist", node)
         pass
+
     def depart_hlist(self, node):
         pass
 
     def visit_hlistcol(self, node):
         # self.log_unknown("hlistcol", node)
         pass
+
     def depart_hlistcol(self, node):
         pass
 
     def visit_admonition(self, node):
         self.new_state(0)
+
     def depart_admonition(self, node):
         self.end_state()
 
     def _visit_admonition(self, node):
         self.new_state(self.indent)
+
     def _make_depart_admonition(name):
         def depart_admonition(self, node):
             self.end_state(first=admonitionlabels[name] + ': ')
@@ -607,39 +666,46 @@ class RstTranslator(TextTranslator):
             self.add_text(versionlabels[node['type']] % node['version'] + ': ')
         else:
             self.add_text(versionlabels[node['type']] % node['version'] + '.')
+
     def depart_versionmodified(self, node):
         self.end_state()
 
     def visit_literal_block(self, node):
         self.add_text("::")
         self.new_state(self.indent)
+
     def depart_literal_block(self, node):
         self.end_state(wrap=False)
 
     def visit_doctest_block(self, node):
         self.new_state(0)
+
     def depart_doctest_block(self, node):
         self.end_state(wrap=False)
 
     def visit_line_block(self, node):
         self.new_state(0)
+
     def depart_line_block(self, node):
         self.end_state(wrap=False)
 
     def visit_line(self, node):
         # self.log_unknown("line", node)
         pass
+
     def depart_line(self, node):
         pass
 
     def visit_block_quote(self, node):
         self.add_text('..')
         self.new_state(self.indent)
+
     def depart_block_quote(self, node):
         self.end_state()
 
     def visit_compact_paragraph(self, node):
         pass
+
     def depart_compact_paragraph(self, node):
         pass
 
@@ -647,6 +713,7 @@ class RstTranslator(TextTranslator):
         if not isinstance(node.parent, nodes.Admonition) or \
                isinstance(node.parent, addnodes.seealso):
             self.new_state(0)
+
     def depart_paragraph(self, node):
         if not isinstance(node.parent, nodes.Admonition) or \
                isinstance(node.parent, addnodes.seealso):
@@ -656,6 +723,7 @@ class RstTranslator(TextTranslator):
         if 'refid' in node:
             self.new_state(0)
             self.add_text('.. _'+node['refid']+':'+self.nl)
+
     def depart_target(self, node):
         if 'refid' in node:
             self.end_state(wrap=False)
@@ -668,6 +736,7 @@ class RstTranslator(TextTranslator):
 
     def visit_pending_xref(self, node):
         pass
+
     def depart_pending_xref(self, node):
         pass
 
@@ -732,27 +801,31 @@ class RstTranslator(TextTranslator):
 
     def visit_download_reference(self, node):
         self.log_unknown("download_reference", node)
-        pass
+
     def depart_download_reference(self, node):
         pass
 
     def visit_emphasis(self, node):
         self.add_text('*')
+
     def depart_emphasis(self, node):
         self.add_text('*')
 
     def visit_literal_emphasis(self, node):
         self.add_text('*')
+
     def depart_literal_emphasis(self, node):
         self.add_text('*')
 
     def visit_strong(self, node):
         self.add_text('**')
+
     def depart_strong(self, node):
         self.add_text('**')
 
     def visit_abbreviation(self, node):
         self.add_text('')
+
     def depart_abbreviation(self, node):
         if node.hasattr('explanation'):
             self.add_text(' (%s)' % node['explanation'])
@@ -760,21 +833,25 @@ class RstTranslator(TextTranslator):
     def visit_title_reference(self, node):
         # self.log_unknown("title_reference", node)
         self.add_text('*')
+
     def depart_title_reference(self, node):
         self.add_text('*')
 
     def visit_literal(self, node):
         self.add_text('``')
+
     def depart_literal(self, node):
         self.add_text('``')
 
     def visit_subscript(self, node):
         self.add_text('_')
+
     def depart_subscript(self, node):
         pass
 
     def visit_superscript(self, node):
         self.add_text('^')
+
     def depart_superscript(self, node):
         pass
 
@@ -788,23 +865,27 @@ class RstTranslator(TextTranslator):
 
     def visit_Text(self, node):
         self.add_text(node.astext())
+
     def depart_Text(self, node):
         pass
 
     def visit_generated(self, node):
         # self.log_unknown("generated", node)
         pass
+
     def depart_generated(self, node):
         pass
 
     def visit_inline(self, node):
         # self.log_unknown("inline", node)
         pass
+
     def depart_inline(self, node):
         pass
 
     def visit_problematic(self, node):
         self.add_text('>>')
+
     def depart_problematic(self, node):
         self.add_text('<<')
 

--- a/sphinxcontrib/writers/rst.py
+++ b/sphinxcontrib/writers/rst.py
@@ -220,7 +220,7 @@ class RstTranslator(TextTranslator):
             self.add_text('``')
 
     def visit_desc_name(self, node):
-        # self.log_unknown("desc_name", node)
+        # Bold named objects (e.g. "this.is.my.**ClassName**\ ")
         self.add_text('**')
         pass
 
@@ -229,8 +229,9 @@ class RstTranslator(TextTranslator):
         pass
 
     def visit_desc_addname(self, node):
+        # Italicize module names before classes
+        # (e.g. "*this.is.my.*\ ClassName")
         self.add_text('*')
-        # self.log_unknown("desc_addname", node)
         pass
 
     def depart_desc_addname(self, node):

--- a/sphinxcontrib/writers/rst.py
+++ b/sphinxcontrib/writers/rst.py
@@ -202,30 +202,39 @@ class RstTranslator(TextTranslator):
     def depart_desc(self, node):
         self.end_state()
 
+    SIGNATURES_TO_SKIP = ('exception', 'class', 'method', 'function')
+
     def visit_desc_signature(self, node):
-        if node.parent['objtype'] in ('class', 'exception', 'method', 'function'):
-            self.add_text('**')
+        # Don't want to bold the entire signature, so we are
+        # passing formatting down to other writer functions.
+        # Example of sub nodes to look for: desc_name, desc_addname,
+        if node.parent['objtype'] in self.SIGNATURES_TO_SKIP:
+            pass
         else:
             self.add_text('``')
 
     def depart_desc_signature(self, node):
-        if node.parent['objtype'] in ('class', 'exception', 'method', 'function'):
-            self.add_text('**')
+        if node.parent['objtype'] in self.SIGNATURES_TO_SKIP:
+            pass
         else:
             self.add_text('``')
 
     def visit_desc_name(self, node):
         # self.log_unknown("desc_name", node)
+        self.add_text('**')
         pass
 
     def depart_desc_name(self, node):
+        self.add_text('**\ ')
         pass
 
     def visit_desc_addname(self, node):
+        self.add_text('*')
         # self.log_unknown("desc_addname", node)
         pass
 
     def depart_desc_addname(self, node):
+        self.add_text('*\ ')
         pass
 
     def visit_desc_type(self, node):
@@ -864,7 +873,12 @@ class RstTranslator(TextTranslator):
         raise nodes.SkipNode
 
     def visit_Text(self, node):
-        self.add_text(node.astext())
+        # Stripping newlines from paragraphs so that we don't
+        # mess with the normal text wrapping.
+        if isinstance(node.parent, nodes.paragraph):
+            self.add_text(node.astext().replace('\n', ' '))
+        else:
+            self.add_text(node.astext())
 
     def depart_Text(self, node):
         pass


### PR DESCRIPTION
This forked repo just adds a bit better support for generating automated documentation for class names and parameters.
now a class looks like: 
![image](https://user-images.githubusercontent.com/1422280/50710047-e30c7180-1037-11e9-9ff9-cad0dc27a53b.png)
before, this whole section was bolded which made it more difficult to scan.
