### PR TITLE
support implicit hyperlink targets & lengthy image directives

### DIFF
--- a/sphinxcontrib/builders/rst.py
+++ b/sphinxcontrib/builders/rst.py
@@ -17,7 +17,7 @@ from os import path
 from docutils.io import StringOutput
 
 from sphinx.builders import Builder
-from sphinx.util.osutil import ensuredir, os_path, SEP
+from sphinx.util.osutil import ensuredir, SEP
 from ..writers.rst import RstWriter
 
 

--- a/sphinxcontrib/writers/rst.py
+++ b/sphinxcontrib/writers/rst.py
@@ -13,7 +13,6 @@ from __future__ import (print_function, unicode_literals, absolute_import)
 
 import os
 import sys
-import re
 import textwrap
 import logging
 
@@ -458,9 +457,14 @@ class RstTranslator(TextTranslator):
         raise nodes.SkipNode
 
     def visit_image(self, node):
-        if 'alt' in node.attributes:
+        self.new_state(0)
+        if 'uri' in node:
+            self.add_text(_('.. image:: %s') % node['uri'])
+        elif 'alt' in node.attributes:
             self.add_text(_('[image: %s]') % node['alt'])
-        self.add_text(_('[image]'))
+        else:
+            self.add_text(_('[image]'))
+        self.end_state(wrap=False)
         raise nodes.SkipNode
 
     def visit_transition(self, node):
@@ -705,7 +709,10 @@ class RstTranslator(TextTranslator):
         Finally, all other links are also converted to an inline link
         format.
         """
-        if 'refuri' not in node:
+        if 'name' not in node:
+            self.add_text('`%s`_' % node.astext())
+            raise nodes.SkipNode
+        elif 'refuri' not in node:
             self.add_text('`%s`_' % node['name'])
             raise nodes.SkipNode
         elif 'internal' not in node:


### PR DESCRIPTION
* implicit hyperlink targets, (generated by the ``.. contents::``
directive), had no handling, and raised an uncaught exception

* ``.. image::`` directives with lengthy URIs were incorrectly rendered
due to ``wrap`` logic

Only with the below changes am I able to render a valid & correct RST document from my Sphinx documentation.