### PR TITLE
Fix subscript and superscript

### DIFF
--- a/sphinxcontrib/writers/rst.py
+++ b/sphinxcontrib/writers/rst.py
@@ -784,9 +784,10 @@ class RstTranslator(TextTranslator):
         self.add_text('`')
 
     def visit_superscript(self, node):
-        self.add_text('^')
+        self.add_text(':sup:`')
+
     def depart_superscript(self, node):
-        pass
+        self.add_text('`')
 
     def visit_footnote_reference(self, node):
         self.add_text('[%s]' % node.astext())

--- a/sphinxcontrib/writers/rst.py
+++ b/sphinxcontrib/writers/rst.py
@@ -778,9 +778,10 @@ class RstTranslator(TextTranslator):
         self.add_text('``')
 
     def visit_subscript(self, node):
-        self.add_text('_')
+        self.add_text(':sub:`')
+
     def depart_subscript(self, node):
-        pass
+        self.add_text('`')
 
     def visit_superscript(self, node):
         self.add_text('^')

--- a/tests/datasets/common/subscript.rst
+++ b/tests/datasets/common/subscript.rst
@@ -1,0 +1,1 @@
+This is :sub:`subscript`.

--- a/tests/datasets/common/superscript.rst
+++ b/tests/datasets/common/superscript.rst
@@ -1,0 +1,1 @@
+This is :sup:`superscript`.

--- a/tests/expected/common/subscript.rst
+++ b/tests/expected/common/subscript.rst
@@ -1,0 +1,1 @@
+This is :sub:`subscript`.

--- a/tests/expected/common/superscript.rst
+++ b/tests/expected/common/superscript.rst
@@ -1,0 +1,1 @@
+This is :sup:`superscript`.

--- a/tests/test_rst_formatting.py
+++ b/tests/test_rst_formatting.py
@@ -35,3 +35,12 @@ def test_subscript(common_src_dir, expected_common_dir):
         parse_doc(out_dir, 'subscript'),
         parse_doc(expected_common_dir, 'subscript'),
     )
+
+
+def test_superscript(common_src_dir, expected_common_dir):
+    out_dir = build_sphinx(common_src_dir, ['superscript'])
+
+    assert_doc_equal(
+        parse_doc(out_dir, 'superscript'),
+        parse_doc(expected_common_dir, 'superscript'),
+    )

--- a/tests/test_rst_formatting.py
+++ b/tests/test_rst_formatting.py
@@ -26,3 +26,12 @@ def test_literal(common_src_dir, expected_common_dir):
         parse_doc(out_dir, 'literal'),
         parse_doc(expected_common_dir, 'literal'),
     )
+
+
+def test_subscript(common_src_dir, expected_common_dir):
+    out_dir = build_sphinx(common_src_dir, ['subscript'])
+
+    assert_doc_equal(
+        parse_doc(out_dir, 'subscript'),
+        parse_doc(expected_common_dir, 'subscript'),
+    )


### PR DESCRIPTION
* `_` does not work for subscript use [:sub:](https://docutils.sourceforge.io/docs/ref/rst/roles.html#subscript) instead
* `^` does not work for superscript use [:sup:](https://docutils.sourceforge.io/docs/ref/rst/roles.html#superscript) instead