### PR TITLE
Fix versionlabels

### DIFF
--- a/sphinxcontrib/writers/rst.py
+++ b/sphinxcontrib/writers/rst.py
@@ -21,11 +21,7 @@ from docutils import nodes, writers
 from sphinx import addnodes
 from sphinx.locale import admonitionlabels, _
 from sphinx.writers.text import TextTranslator, MAXWIDTH, STDINDENT
-try:
-    from sphinx.domains.changeset import versionlabels
-except ImportErrror:
-    # Support for Sphinx < 1.8.0
-    from sphinx.locale import versionlabels
+
 
 class RstWriter(writers.Writer):
     supported = ('text',)
@@ -613,10 +609,6 @@ class RstTranslator(TextTranslator):
 
     def visit_versionmodified(self, node):
         self.new_state(0)
-        if node.children:
-            self.add_text(versionlabels[node['type']] % node['version'] + ': ')
-        else:
-            self.add_text(versionlabels[node['type']] % node['version'] + '.')
     def depart_versionmodified(self, node):
         self.end_state()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,3 +15,18 @@ def expected_common_dir():
     return os.path.join(
         os.path.dirname(os.path.realpath(__file__)), 'expected', 'common'
     )
+
+
+@pytest.fixture
+def sphinx_src_dir():
+    return os.path.join(
+        os.path.dirname(os.path.realpath(__file__)), 'datasets', 'sphinx-specific'
+    )
+
+
+@pytest.fixture
+def expected_sphinx_dir():
+    return os.path.join(
+        os.path.dirname(os.path.realpath(__file__)), 'expected', 'sphinx-specific'
+    )
+

--- a/tests/datasets/sphinx-specific/versionmodified.rst
+++ b/tests/datasets/sphinx-specific/versionmodified.rst
@@ -1,0 +1,9 @@
+.. versionadded:: 0.3.1
+
+.. versionchanged:: 1.7.0
+   The spam parameter is turned on by default.
+
+.. deprecated:: 2.5.0
+   Common sense is deprecated altogether.
+
+versionmodified directives are Sphinx-specific and not preserved.

--- a/tests/expected/sphinx-specific/versionmodified.rst
+++ b/tests/expected/sphinx-specific/versionmodified.rst
@@ -1,0 +1,7 @@
+New in version 0.3.1.
+
+Changed in version 1.7.0: The spam parameter is turned on by default.
+
+Deprecated since version 2.5.0: Common sense is deprecated altogether.
+
+versionmodified directives are Sphinx-specific and not preserved.

--- a/tests/test_sphinx_versionmodified.py
+++ b/tests/test_sphinx_versionmodified.py
@@ -1,0 +1,9 @@
+from tests.utils import build_sphinx, assert_doc_equal, parse_doc
+
+def test_versionadded(sphinx_src_dir, expected_sphinx_dir):
+    out_dir = build_sphinx(sphinx_src_dir, ['versionmodified'])
+
+    assert_doc_equal(
+        parse_doc(out_dir, 'versionmodified'),
+        parse_doc(expected_sphinx_dir, 'versionmodified'),
+    )


### PR DESCRIPTION
Fix versionadded: no duplicate labels. …

Previously `.. versionadded:: 0.3.1` would print:

    New in version 0.3.1: New in version 0.3.1.

Now it prints:

    New in version 0.3.1.